### PR TITLE
Add ContentType for creating job

### DIFF
--- a/kubernetes/lib/kubernetes/api/batch_v1_api.rb
+++ b/kubernetes/lib/kubernetes/api/batch_v1_api.rb
@@ -63,7 +63,7 @@ module Kubernetes
       # HTTP header 'Accept' (if needed)
       header_params['Accept'] = @api_client.select_header_accept(['application/json', 'application/yaml', 'application/vnd.kubernetes.protobuf'])
       # HTTP header 'Content-Type'
-      header_params['Content-Type'] = @api_client.select_header_content_type(['*/*'])
+      header_params['Content-Type'] = @api_client.select_header_content_type(['application/json', '*/*'])
 
       # form parameters
       form_params = {}


### PR DESCRIPTION
When create job by this library, "UnsupportedMediaType" error was occured.
This patch fixes it.