### PR TITLE
Fix issues with certificate based auth

### DIFF
--- a/kubernetes/spec/utils_spec.rb
+++ b/kubernetes/spec/utils_spec.rb
@@ -86,6 +86,10 @@ describe Kubernetes do
   end
 
   context '#create_temp_file_with_base64content' do
+    before do
+      Kubernetes.clear_temp_files
+    end
+
     context 'when it is called at first time' do
       it 'should return temp file path' do
         expected_path = 'tempfile-path'
@@ -102,12 +106,8 @@ describe Kubernetes do
 
     context 'when it is already called' do
       it 'should return cached value' do
-        expected_path = 'tempfile-path'
         content = TEST_DATA_BASE64
-        Kubernetes.cache_temp_file(content, expected_path)
-        io = double('io')
-        expect(io).not_to receive(:path)
-        expect(io).not_to receive(:write).with(TEST_DATA)
+        expected_path = Kubernetes.create_temp_file_with_base64content(content)
 
         path = Kubernetes.create_temp_file_with_base64content(content)
         expect(path).to eq(expected_path)

--- a/kubernetes/src/kubernetes/config/kube_config.rb
+++ b/kubernetes/src/kubernetes/config/kube_config.rb
@@ -20,6 +20,7 @@ require 'uri'
 require 'kubernetes/api_client'
 require 'kubernetes/configuration'
 require 'kubernetes/config/error'
+require 'kubernetes/utils'
 
 module Kubernetes
   # The KubeConfig class represents configuration based on a YAML

--- a/kubernetes/src/kubernetes/utils.rb
+++ b/kubernetes/src/kubernetes/utils.rb
@@ -82,7 +82,11 @@ module Kubernetes
     @temp_files[content].path
   end
 
+  def clear_temp_files
+    @temp_files = {}
+  end
+
   module_function :new_client_from_config, :load_incluster_config,
                   :load_kube_config, :create_temp_file_and_set,
-                  :create_temp_file_with_base64content
+                  :create_temp_file_with_base64content, :clear_temp_files
 end

--- a/kubernetes/src/kubernetes/utils.rb
+++ b/kubernetes/src/kubernetes/utils.rb
@@ -76,15 +76,13 @@ module Kubernetes
   def create_temp_file_with_base64content(content)
     @temp_files[content] ||= Tempfile.open('kube') do |temp|
       temp.write(Base64.strict_decode64(content))
-      temp.path
+      temp
     end
-  end
 
-  def cache_temp_file(content, path)
-    @temp_files[content] = path
+    @temp_files[content].path
   end
 
   module_function :new_client_from_config, :load_incluster_config,
                   :load_kube_config, :create_temp_file_and_set,
-                  :create_temp_file_with_base64content, :cache_temp_file
+                  :create_temp_file_with_base64content
 end


### PR DESCRIPTION
This PR fixes two different bugs: a missing import and a tempfile issue. The existence of both of these bugs actually prevents using kubeconfig files containing certificates. More precise descriptions of the fixes are in the commit messages.
