### PR TITLE
Fix a bug parsing kubeconfig if the user context was empty string.

### DIFF
--- a/kubernetes/spec/config/kube_config_spec.rb
+++ b/kubernetes/spec/config/kube_config_spec.rb
@@ -40,6 +40,19 @@ describe Kubernetes::KubeConfig do
       end
     end
 
+    context 'if empty user context is given' do
+      it 'should configure non user configuration' do
+        expected = Kubernetes::Configuration.new do |c|
+          c.scheme = 'http'
+          c.host = 'test-host:80'
+        end
+        actual = Kubernetes::Configuration.new
+
+        kube_config.configure(actual, 'empty_user')
+        expect(actual).to be_same_configuration_as(expected)
+      end
+    end
+
     context 'if ssl context is given' do
       it 'should configure ssl configuration' do
         expected = Kubernetes::Configuration.new do |c|
@@ -214,7 +227,9 @@ describe Kubernetes::KubeConfig do
 
   context '#list_context_names' do
     it 'should list context names' do
-      arr = %w[default no_user context_ssl context_insecure context_token].sort
+      # rubocop:disable LineLength
+      arr = %w[default no_user empty_user context_ssl context_insecure context_token].sort
+      # rubocop:enable LineLength
       expect(kube_config.list_context_names.sort).to eq(arr)
     end
   end

--- a/kubernetes/spec/fixtures/config/kube_config_hash.rb
+++ b/kubernetes/spec/fixtures/config/kube_config_hash.rb
@@ -48,6 +48,13 @@ TEST_CONTEXT_NO_USER = {
     'cluster' => 'default'
   }
 }.freeze
+TEST_CONTEXT_EMPTY_USER = {
+  'name' => 'empty_user',
+  'context' => {
+    'cluster' => 'default',
+    'user' => ''
+  }
+}.freeze
 TEST_CONTEXT_SSL = {
   'name' => 'context_ssl',
   'context' => {
@@ -164,6 +171,7 @@ TEST_KUBE_CONFIG = {
   'contexts' => [
     TEST_CONTEXT_DEFAULT,
     TEST_CONTEXT_NO_USER,
+    TEST_CONTEXT_EMPTY_USER,
     TEST_CONTEXT_SSL,
     TEST_CONTEXT_TOKEN,
     TEST_CONTEXT_INSECURE

--- a/kubernetes/src/kubernetes/config/kube_config.rb
+++ b/kubernetes/src/kubernetes/config/kube_config.rb
@@ -146,7 +146,9 @@ module Kubernetes
         if context['cluster']
           context['cluster'] = find_cluster(context['cluster'])
         end
-        context['user'] = find_user(context['user']) if context['user']
+        if context['user'] && !context['user'].empty?
+          context['user'] = find_user(context['user'])
+        end
       end
     end
 
@@ -162,7 +164,7 @@ module Kubernetes
       obj = list.find { |item| item['name'] == name }
       raise ConfigError, "#{key}: #{name} not found" unless obj
 
-      obj[key].dup
+      obj[key].dup if obj[key]
     end
   end
   # rubocop:enable ClassLength


### PR DESCRIPTION
@drubin 