### PR TITLE
Remove inactive members from OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,8 +1,9 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 approvers:
 - brendandburns
-- mbohlool
 reviewers:
 - brendandburns
-- mbohlool
 - drubin
+emeritus_approvers:
+- mbohlool
+


### PR DESCRIPTION
ref: https://github.com/kubernetes/org/issues/2456

As a part of cleaning up inactive members (those with no activity within
the past 18 months) from OWNERS files, this commit moves mbohlool from
an approver to emeritus_approver.